### PR TITLE
Og ui memberships scaling for large groups

### DIFF
--- a/og.module
+++ b/og.module
@@ -203,7 +203,7 @@ function og_og_membership_access(OgMembershipInterface $entity, $operation, Acco
   }
 
   // Ensure that there's at least one member in the group.
-  if ($operation === 'delete' && count(Og::getGroupMemberships($group)) === 1) {
+  if ($operation === 'delete' && \Drupal::service('og.membership_manager')->getGroupMembershipCount($group) === 1) {
     return AccessResult::forbidden();
   }
 

--- a/src/MembershipManager.php
+++ b/src/MembershipManager.php
@@ -173,6 +173,23 @@ class MembershipManager implements MembershipManagerInterface {
   /**
    * {@inheritdoc}
    */
+  public function getGroupMembershipCount(EntityInterface $group, array $states = [OgMembershipInterface::STATE_ACTIVE]) {
+    $query = $this->entityTypeManager
+      ->getStorage('og_membership')
+      ->getQuery()
+      ->condition('entity_id', $group->id());
+
+    if ($states) {
+      $query->condition('state', $states, 'IN');
+    }
+
+    $query->count();
+    return $query->execute();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function createMembership(EntityInterface $group, AccountInterface $user, $membership_type = OgMembershipInterface::TYPE_DEFAULT) {
     /** @var \Drupal\user\UserInterface|\Drupal\Core\Session\AccountInterface $user */
     /** @var \Drupal\og\OgMembershipInterface $membership */

--- a/src/MembershipManager.php
+++ b/src/MembershipManager.php
@@ -134,45 +134,6 @@ class MembershipManager implements MembershipManagerInterface {
   /**
    * {@inheritdoc}
    */
-  public function getGroupMemberships(EntityInterface $group, array $states = [OgMembershipInterface::STATE_ACTIVE]) {
-    // Get a string identifier of the states, so we can retrieve it from cache.
-    sort($states);
-    $states_identifier = implode('|', array_unique($states));
-
-    $identifier = [
-      __METHOD__,
-      $group->id(),
-      $states_identifier,
-    ];
-    $identifier = implode(':', $identifier);
-
-    // Return cached result if it exists.
-    if (isset($this->cache[$identifier])) {
-      return $this->cache[$identifier];
-    }
-
-    $query = $this->entityTypeManager
-      ->getStorage('og_membership')
-      ->getQuery()
-      ->condition('entity_id', $group->id());
-
-    if ($states) {
-      $query->condition('state', $states, 'IN');
-    }
-
-    $results = $query->execute();
-
-    /** @var \Drupal\og\Entity\OgMembership[] $memberships */
-    $this->cache[$identifier] = $this->entityTypeManager
-      ->getStorage('og_membership')
-      ->loadMultiple($results);
-
-    return $this->cache[$identifier];
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function getGroupMembershipCount(EntityInterface $group, array $states = [OgMembershipInterface::STATE_ACTIVE]) {
     $query = $this->entityTypeManager
       ->getStorage('og_membership')

--- a/src/MembershipManagerInterface.php
+++ b/src/MembershipManagerInterface.php
@@ -82,6 +82,19 @@ interface MembershipManagerInterface {
   public function getGroupMemberships(EntityInterface $group, array $states = [OgMembershipInterface::STATE_ACTIVE]);
 
   /**
+   * Returns the number of group memberships for a given group.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $group
+   *   The group to get the membership for.
+   * @param array $states
+   *   (optional) Array with the state to return. Defaults to active.
+   *
+   * @return int
+   *   The number of memberships for the group.
+   */
+  public function getGroupMembershipCount(EntityInterface $group, array $states = [OgMembershipInterface::STATE_ACTIVE]);
+
+  /**
    * Returns the group membership for a given user and group.
    *
    * @param \Drupal\Core\Entity\EntityInterface $group

--- a/src/MembershipManagerInterface.php
+++ b/src/MembershipManagerInterface.php
@@ -69,19 +69,6 @@ interface MembershipManagerInterface {
   public function getMemberships(AccountInterface $user, array $states = [OgMembershipInterface::STATE_ACTIVE]);
 
   /**
-   * Returns the group memberships for a given group.
-   *
-   * @param \Drupal\Core\Entity\EntityInterface $group
-   *   The group to get the membership for.
-   * @param array $states
-   *   (optional) Array with the state to return. Defaults to active.
-   *
-   * @return \Drupal\og\OgMembershipInterface[]
-   *   An array of OgMembership entities, keyed by ID.
-   */
-  public function getGroupMemberships(EntityInterface $group, array $states = [OgMembershipInterface::STATE_ACTIVE]);
-
-  /**
    * Returns the number of group memberships for a given group.
    *
    * @param \Drupal\Core\Entity\EntityInterface $group

--- a/src/Plugin/Validation/Constraint/UniqueOgMembershipConstraintValidator.php
+++ b/src/Plugin/Validation/Constraint/UniqueOgMembershipConstraintValidator.php
@@ -7,6 +7,13 @@ use Symfony\Component\Validator\ConstraintValidator;
 
 /**
  * Ensures that new members added to a group do not already exist.
+ *
+ * Note that in typical operation, this validation constraint will not come into
+ * play, as the membership entity's uid field is already validated by core's
+ * ValidReferenceConstraint, which hands over to the entity reference selection
+ * plugin. In our case, that is
+ * \Drupal\og\Plugin\EntityReferenceSelection\OgUserSelection, which already
+ * checks an existing member cannot be added to the group again.
  */
 class UniqueOgMembershipConstraintValidator extends ConstraintValidator {
 


### PR DESCRIPTION
Fixes various issues that affect the OG Membership entity form with large groups:

- Fixed og_og_membership_access() loads all membership entities needlessly
- Changed OgUserSelection to alter the selection query rather than load all membership entities to use their uids as a query condition
- Fixed UniqueOgMembershipConstraintValidator loading all membership entities to check for a user's existing membership.

I've also taken the liberty of removing getGroupMemberships(). This branch added it, but with my changes, it is no longer used at all. It's not scalable, so I think it's best if we don't have it at all, to avoid developers using it and causing more performance problems.
